### PR TITLE
Pending tasks will no longer be numbered weird when ported over

### DIFF
--- a/build/bot/controllers/days/startDay.js
+++ b/build/bot/controllers/days/startDay.js
@@ -151,6 +151,12 @@ exports.default = function (controller) {
 					} else {
 						// has pending tasks
 						dailyTasks = (0, _messageHelpers.convertToSingleTaskObjectArray)(dailyTasks, "daily");
+						// remove "priority" on them
+						dailyTasks = dailyTasks.map(function (dailyTask) {
+							if (dailyTask.dataValues && dailyTask.dataValues.priority) delete dailyTask.dataValues.priority;
+							return dailyTask;
+						});
+
 						convo.dayStart.pendingTasks = dailyTasks;
 						(0, _plan.showPendingTasks)(err, convo);
 					}

--- a/src/bot/controllers/days/startDay.js
+++ b/src/bot/controllers/days/startDay.js
@@ -182,6 +182,13 @@ export default function(controller) {
 					} else {
 						// has pending tasks
 						dailyTasks = convertToSingleTaskObjectArray(dailyTasks, "daily");
+						// remove "priority" on them
+						dailyTasks = dailyTasks.map((dailyTask) => {
+							if (dailyTask.dataValues && dailyTask.dataValues.priority)
+								delete dailyTask.dataValues.priority;
+							return dailyTask;
+						});
+
 						convo.dayStart.pendingTasks = dailyTasks;
 						showPendingTasks(err, convo);
 					}


### PR DESCRIPTION
Fixes numbering issue when porting over pending tasks for a new plan
