### PR TITLE
Organizing by dailyTask.updatedAt will put task last when undeleting or uncomplying

### DIFF
--- a/build/bot/lib/miscHelpers.js
+++ b/build/bot/lib/miscHelpers.js
@@ -261,7 +261,7 @@ function prioritizeDailyTasks(user) {
 	user.getDailyTasks({
 		where: ['"DailyTask"."type" = ?', "live"],
 		include: [_models2.default.Task],
-		order: '"Task"."done" = FALSE DESC, "DailyTask"."type" = \'live\' DESC, "DailyTask"."priority" ASC'
+		order: '"Task"."done" = FALSE DESC, "DailyTask"."type" = \'live\' DESC, "DailyTask"."updatedAt" ASC, "DailyTask"."priority" ASC'
 	}).then(function (dailyTasks) {
 		dailyTasks.forEach(function (dailyTask, index) {
 			var priority = index + 1;

--- a/src/bot/lib/miscHelpers.js
+++ b/src/bot/lib/miscHelpers.js
@@ -236,7 +236,7 @@ export function prioritizeDailyTasks(user) {
 	user.getDailyTasks({
 		where: [ `"DailyTask"."type" = ?`, "live" ],
 		include: [ models.Task ],
-		order: `"Task"."done" = FALSE DESC, "DailyTask"."type" = 'live' DESC, "DailyTask"."priority" ASC`
+		order: `"Task"."done" = FALSE DESC, "DailyTask"."type" = 'live' DESC, "DailyTask"."updatedAt" ASC, "DailyTask"."priority" ASC`
 	})
 	.then((dailyTasks) => {
 		dailyTasks.forEach((dailyTask, index) => {


### PR DESCRIPTION
Another simple PR to make sure that when you undelete or uncomplete a task, it will append that task at the very end of your task list. that way you can still do actions on your most recently shown taskList and have the numbers match up properly
